### PR TITLE
setAreaCode() Adjustment for app state error

### DIFF
--- a/Console/Command/ChangeCustomerPassword.php
+++ b/Console/Command/ChangeCustomerPassword.php
@@ -104,7 +104,6 @@ class ChangeCustomerPassword extends Command
         $this->accountManagement = $accountManagement;
         $this->state = $state;
         $this->helper = $helper;
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
         parent::__construct();
     }
 
@@ -118,7 +117,7 @@ class ChangeCustomerPassword extends Command
         InputInterface $input,
         OutputInterface $output
     ) {
-        //$this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
         $customerId = $input->getOption(self::ARG_CUSTOMER_ID);
         $customerEmail = $input->getOption(self::ARG_CUSTOMER_EMAIL);
         $password = $input->getOption(self::ARG_CUSTOMER_PASSWORD);


### PR DESCRIPTION
Moving $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML); to the execute function to stop the console error that deals with the app state and stops magento's consumers from functioning.