### PR TITLE
Moved setting area from construct to execute to avoid Area code is al…

### DIFF
--- a/Console/Command/ChangeCustomerPassword.php
+++ b/Console/Command/ChangeCustomerPassword.php
@@ -104,7 +104,6 @@ class ChangeCustomerPassword extends Command
         $this->accountManagement = $accountManagement;
         $this->state = $state;
         $this->helper = $helper;
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
         parent::__construct();
     }
 
@@ -118,7 +117,7 @@ class ChangeCustomerPassword extends Command
         InputInterface $input,
         OutputInterface $output
     ) {
-        //$this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
         $customerId = $input->getOption(self::ARG_CUSTOMER_ID);
         $customerEmail = $input->getOption(self::ARG_CUSTOMER_EMAIL);
         $password = $input->getOption(self::ARG_CUSTOMER_PASSWORD);


### PR DESCRIPTION
…ready set errors in bin/magento

Never set an areacode in the constructor - when bin/magento is run, all constructors of all console commands are executed