### PR TITLE
Adding autocomplete="off"

### DIFF
--- a/view/adminhtml/web/template/form/element/password.html
+++ b/view/adminhtml/web/template/form/element/password.html
@@ -12,7 +12,7 @@
  * @license    https://kiwicommerce.co.uk/magento2-extension-license/
  */
  -->
-<input class="admin__control-text" type="password"
+<input class="admin__control-text" type="password" autocomplete="off"
        data-bind="
         event: {change: userChanges},
         value: value,
@@ -23,6 +23,5 @@
             placeholder: placeholder,
             'aria-describedby': noticeId,
             id: uid,
-            disabled: disabled,
-            autocomplete: 'off'
+            disabled: disabled
     }"/>

--- a/view/adminhtml/web/template/form/element/password.html
+++ b/view/adminhtml/web/template/form/element/password.html
@@ -23,5 +23,6 @@
             placeholder: placeholder,
             'aria-describedby': noticeId,
             id: uid,
-            disabled: disabled
+            disabled: disabled,
+            autocomplete: 'off'
     }"/>


### PR DESCRIPTION
Adding autocomplete="off" to prevent issues in admin where browser autocomplete would interfere/confuse with admin-related Change Password functionality.